### PR TITLE
Add slug

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -116,7 +116,20 @@ class SitesController < ApplicationController
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_site
-      @site = Site.find(params[:id])
+      @site = if params[:id] =~ /\A\d+\z/
+        Site.find(params[:id])
+      else
+        Site.find_by(slug: params[:id])
+      end
+
+      if @site.nil?
+        respond_to do |format|
+          format.html { render :file => 'public/404', :status => :not_found, :layout => false }
+          format.json { render :json => {:errors => "Invalid ID or slug. Site not found for '#{params[:id]}'"}, :status => :not_found }
+        end
+        return
+      end
+
       @sitecoordinator = if @site.sitecoordinator.nil?
         nil
       else

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -50,6 +50,9 @@ class SitesController < ApplicationController
   # POST /sites.json
   def create
     @site = Site.new(site_params)
+    if @site.slug.to_s.strip.empty?
+      @site.slug = @site.name.parameterize
+    end
     
     respond_to do |format|
       if is_admin?
@@ -57,7 +60,11 @@ class SitesController < ApplicationController
           format.html { redirect_to @site, notice: 'Site was successfully created.' }
           format.json { render :show, status: :created, location: @site }
         else
-          format.html { render :new }
+          format.html do
+            @eligible_sitecoordinators = User.all.map {|u| u.has_role?('SiteCoordinator') ? [u.email, u.id] : nil}.compact
+            @eligible_sitecoordinators = [] unless @eligible_sitecoordinators
+            render :new
+          end
           format.json { render json: @site.errors, status: :unprocessable_entity }
         end
       else
@@ -76,7 +83,11 @@ class SitesController < ApplicationController
           format.html { redirect_to @site, notice: 'Site was successfully updated.' }
           format.json { render :show, status: :ok, location: @site }
         else
-          format.html { render :edit }
+          format.html do
+            @eligible_sitecoordinators = User.all.map {|u| u.has_role?('SiteCoordinator') ? [u.email, u.id] : nil}.compact
+            @eligible_sitecoordinators = [] unless @eligible_sitecoordinators
+            render :edit
+          end
           format.json { render json: @site.errors, status: :unprocessable_entity }
         end
       else
@@ -115,7 +126,7 @@ class SitesController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def site_params
-      params.require(:site).permit(:name, 
+      params.require(:site).permit(:name, :slug,
         :google_place_id, :street, :city, :state, :zip, :latitude, :longitude, 
         :sitecoordinator, :sitestatus)
     end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -4,4 +4,16 @@ class Site < ApplicationRecord
             in: VALID_SITE_STATUSES,
             message: "%{value} is not a valid status. Must be one of #{VALID_SITE_STATUSES.join(', ')}" 
         }
+
+    before_validation :slugify_self
+    def slugify_self
+        self.slug = (self.slug.nil? || self.slug.to_s.strip.empty?) ? self.name.parameterize : self.slug
+    end
+    validates :slug, {
+        uniqueness: true,
+        format: {
+            with: /\A[a-z0-9-]+-?(-[a-z0-9-]+)*\z/,
+            message: 'Must be a valid URL segment, using lowercase latin characters and single dashes. Leave blank to have a slug auto-generated from your sitename.'
+        }
+    }
 end

--- a/app/views/sites/_form.html.erb
+++ b/app/views/sites/_form.html.erb
@@ -17,6 +17,11 @@
   </div>
 
   <div class="field">
+    <%= f.label :slug %>
+    <%= f.text_field :slug %>
+  </div>
+
+  <div class="field">
     <%= f.label :google_place_id, 'Google Maps Place ID' %>
     <%= f.text_field :google_place_id %>
   </div>

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -4,12 +4,10 @@
   <thead>
     <tr>
       <th>Name</th>
-      <th>Street</th>
-      <th>City</th>
-      <th>State</th>
-      <th>Zip</th>
-      <th>Latitude</th>
-      <th>Longitude</th>
+      <th>Slug</th>
+      <th>Address</th>
+      <th>Coordinates</th>
+      <th>Place ID</th>
       <th>Site Coordinator</th>
       <th>Current Status</th>
       <% if is_admin? %>
@@ -23,12 +21,10 @@
       <% sc = (site.sitecoordinator.nil?) ? nil : User.find(site.sitecoordinator) %>
       <tr>
         <td><%= link_to site.name, site %></td>
-        <td><%= site.street %></td>
-        <td><%= site.city %></td>
-        <td><%= site.state %></td>
-        <td><%= site.zip %></td>
-        <td><%= site.latitude %></td>
-        <td><%= site.longitude %></td>
+        <td><%= site.slug %></td>
+        <td><%= site.street %>, <%= site.city %>, <%= site.state %> <%= site.zip %></td>
+        <td><%= site.latitude %>, <%= site.longitude %></td>
+        <td><%= site.google_place_id %>
         <td><%= (sc.nil?) ? 'None Assigned' : sc.email %></td>
         <td><%= site.sitestatus %></td>
         <% if is_admin? %>

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -4,33 +4,23 @@
 </p>
 
 <p>
-  <strong>Street:</strong>
-  <%= @site.street %>
+  <strong>Slug:</strong>
+  <%= @site.slug %>
 </p>
 
 <p>
-  <strong>City:</strong>
-  <%= @site.city %>
+  <strong>Address</strong>
+  <%= @site.street %>, <%= @site.city %>, <%= @site.state %> <%= @site.zip %>
 </p>
 
 <p>
-  <strong>State:</strong>
-  <%= @site.state %>
+  <strong>Google Place ID:</strong>
+  <%= @site.google_place_id %>
 </p>
 
 <p>
-  <strong>Zip:</strong>
-  <%= @site.zip %>
-</p>
-
-<p>
-  <strong>Latitude:</strong>
-  <%= @site.latitude %>
-</p>
-
-<p>
-  <strong>Longitude:</strong>
-  <%= @site.longitude %>
+  <strong>Coordinates:</strong>
+  <%= @site.latitude %>, <%= @site.longitude %>
 </p>
 
 <p>

--- a/db/migrate/20170728203139_add_slug_to_site.rb
+++ b/db/migrate/20170728203139_add_slug_to_site.rb
@@ -1,0 +1,6 @@
+class AddSlugToSite < ActiveRecord::Migration[5.0]
+  def change
+    add_column :sites, :slug, :string
+    add_index :sites, :slug
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170725214549) do
+ActiveRecord::Schema.define(version: 20170728203139) do
 
   create_table "role_grants", force: :cascade do |t|
     t.integer  "role_id"
@@ -40,6 +40,8 @@ ActiveRecord::Schema.define(version: 20170725214549) do
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
     t.string   "google_place_id"
+    t.string   "slug"
+    t.index ["slug"], name: "index_sites_on_slug"
   end
 
   create_table "users", force: :cascade do |t|

--- a/test/controllers/sites_controller_json_test.rb
+++ b/test/controllers/sites_controller_json_test.rb
@@ -419,7 +419,38 @@ class SitesControllerJsonTest < ActionDispatch::IntegrationTest
     assert_difference('Site.count', 1) do
       post sites_url, 
         params: {
-          city: @site.city, latitude: @site.latitude, longitude: @site.longitude, name: @site.name, sitecoordinator: @site.sitecoordinator, sitestatus: @site.sitestatus, state: @site.state, street: @site.street, zip: @site.zip 
+          slug: "admin-create-test-slug", city: @site.city, latitude: @site.latitude, longitude: @site.longitude, name: @site.name+" new site", sitecoordinator: @site.sitecoordinator, sitestatus: @site.sitestatus, state: @site.state, street: @site.street, zip: @site.zip 
+        }.to_json,
+        headers: {
+          'Accept' => 'application/json',
+          'Content-Type' => 'application/json',
+          'Cookie' => cookie,
+        }
+    end
+
+    assert_response :success
+  end
+
+  test "should create site without a slug when logged in to a Admin via JSON" do
+    # Login
+    post login_url, 
+      params: {
+        email: @admin.email,
+        password: 'user-two-password'
+      }.to_json,
+      headers: {
+        'Accept' => 'application/json',
+        'Content-Type' => 'application/json'
+      }
+    assert_response :success
+    # Harvest the cookie
+    cookie = response.headers['Set-Cookie']
+    assert_not_nil(cookie, 'No cookie harvested')
+    
+    assert_difference('Site.count', 1) do
+      post sites_url, 
+        params: {
+          city: @site.city, latitude: @site.latitude, longitude: @site.longitude, name: @site.name+" new site", sitecoordinator: @site.sitecoordinator, sitestatus: @site.sitestatus, state: @site.state, street: @site.street, zip: @site.zip 
         }.to_json,
         headers: {
           'Accept' => 'application/json',

--- a/test/controllers/sites_controller_test.rb
+++ b/test/controllers/sites_controller_test.rb
@@ -59,6 +59,7 @@ class SitesControllerTest < ActionDispatch::IntegrationTest
     get site_url(@site)
     assert_response :success
   end
+
   test "should show site even without a coordinator" do
     @site.sitecoordinator = nil
     @site.save

--- a/test/controllers/sites_controller_test.rb
+++ b/test/controllers/sites_controller_test.rb
@@ -136,10 +136,10 @@ class SitesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "should  create site when logged in as a Admin" do
+  test "should create site when logged in as a Admin" do
     post login_path, params: {session: {email: @admin.email, password: 'user-two-password'}}
     assert_difference('Site.count', 1) do
-      post sites_url, params: { site: { city: @site.city, latitude: @site.latitude, longitude: @site.longitude, name: @site.name, sitecoordinator: @site.sitecoordinator, sitestatus: @site.sitestatus, state: @site.state, street: @site.street, zip: @site.zip } }
+      post sites_url, params: { site: { city: @site.city, latitude: @site.latitude, longitude: @site.longitude, name: @site.name+" new site", sitecoordinator: @site.sitecoordinator, sitestatus: @site.sitestatus, state: @site.state, street: @site.street, zip: @site.zip } }
     end
 
     assert_redirected_to(site_url(Site.last.id))
@@ -151,13 +151,13 @@ class SitesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "should not update site when logged in as a Admin" do
+  test "should update site when logged in as a Admin" do
     post login_path, params: {session: {email: @admin.email, password: 'user-two-password'}}
     patch site_url(@site), params: { site: { city: @site.city, latitude: @site.latitude, longitude: @site.longitude, name: @site.name, sitecoordinator: @site.sitecoordinator, sitestatus: @site.sitestatus, state: @site.state, street: @site.street, zip: @site.zip } }
     assert_redirected_to(site_url(@site))
   end
 
-  test "should not destroy site when logged in as a Admin" do
+  test "should destroy site when logged in as a Admin" do
     post login_path, params: {session: {email: @admin.email, password: 'user-two-password'}}
     assert_difference('Site.count', -1) do
       delete site_url(@site)

--- a/test/fixtures/sites.yml
+++ b/test/fixtures/sites.yml
@@ -10,6 +10,8 @@ the_alamo:
   longitude:  -98.486277
   sitecoordinator: null
   sitestatus: Open
+  slug: the-alamo
+  google_place_id: hIJX4k2TVVfXIYRIsTnhA-P-Rc
 
 the_cathedral:
   name: San Fernando Cathedral
@@ -21,3 +23,4 @@ the_cathedral:
   longitude: -98.493928
   sitecoordinator: null
   sitestatus: Closed
+  slug: san-fernando-cathedral

--- a/test/models/site_test.rb
+++ b/test/models/site_test.rb
@@ -10,9 +10,28 @@ class SiteTest < ActiveSupport::TestCase
     site.latitude = '29.425729'
     site.longitude = '-98.486277'
     site.sitestatus = 'Closed'
+    site.slug = 'new-site'
 
     assert site.valid?
     assert site.save
+  end
+
+  test "create new site with auto-slugify" do
+    site = Site.new
+    site.name = 'New Site'
+    site.street = '300 Alamo Plaza'
+    site.city = 'San Antonio'
+    site.zip  = '78205'
+    site.latitude = '29.425729'
+    site.longitude = '-98.486277'
+    site.sitestatus = 'Closed'
+    # site.slug = 'new-site'
+
+    assert_nil(site.slug)
+
+    assert( site.valid?, 'Site is invalid without its slug set')
+    assert( site.save, 'Site failed to save without a manually-set slug' )
+    assert_equal('new-site', site.slug)
   end
 
   test 'sitestatus should validate against a list' do


### PR DESCRIPTION
Adds slug field to Site model.

Sites submitted (or updated) without a slug will have one auto-generated by the server.